### PR TITLE
feat: show references with author-year

### DIFF
--- a/apis_ontology/templates/apis_ontology/partials/iabasemodel_card_table.html
+++ b/apis_ontology/templates/apis_ontology/partials/iabasemodel_card_table.html
@@ -1,0 +1,17 @@
+{% load generic %}
+{% load references %}
+<table class="table table-hover">
+    {% modeldict object as d %}
+    {% for key, value in d.items %}
+    {% model_field_template_lookup_list object key "table_row" as template_list %}
+    {% include template_list %}
+    {% endfor %}
+</table>
+<div id="referenceon{{ object.content_type.id }}_{{ object.pk }}dlg">
+    References:
+<ul>
+  {% for ref in object.content_type.id|get_references:object.pk %}
+    <li>{{ ref }}</li>
+    {% endfor %}
+    </ul>
+</div>

--- a/apis_ontology/templates/columns/bibsonomy.html
+++ b/apis_ontology/templates/columns/bibsonomy.html
@@ -1,0 +1,2 @@
+{% load bibsonomy_templatetags %}
+{% link_to_reference_on obj=record modal=True %}

--- a/apis_ontology/templatetags/references.py
+++ b/apis_ontology/templatetags/references.py
@@ -1,0 +1,26 @@
+from django import template
+from apis_bibsonomy.models import Reference
+import json
+
+register = template.Library()
+
+
+@register.filter
+def get_references(content_type, object_id):
+    refs_qs = Reference.objects.filter(content_type=content_type, object_id=object_id)
+    formatted_refs = []
+
+    for ref in refs_qs:
+        # Assuming ref.bibtex is stored as JSON string
+        data = json.loads(ref.bibtex)
+        author = data["author"][0]
+        year = data["issued"]["date-parts"][0][0]
+        title = data["title"]
+        formatted_refs.append(
+            f"{author['family']}, {author['given']} ({year}). {title}"
+        )
+
+    return formatted_refs
+
+
+# ref['author'][0]['family']}, {ref['author'][0]['given']} ({ref['issued']['date-parts'][0][0]}).


### PR DESCRIPTION
This pull request introduces new functionality for displaying and formatting bibliographic references related to ontology model objects. The main changes include adding a custom Django template filter to retrieve and format references, updating templates to display these references, and integrating new template tags.

**Reference display and formatting improvements:**

* Added a new template filter `get_references` in `references.py` to retrieve and format references for a given object using its `content_type` and `object_id`. This filter processes the `bibtex` JSON field and outputs a formatted citation string.
* Updated the `iabasemodel_card_table.html` template to display a list of formatted references for the current object below its details, utilizing the new `get_references` filter.

**Template tag integration:**

* Added `{% load references %}` and `{% load generic %}` to `iabasemodel_card_table.html` to enable use of the new filter and related template tags.
* Updated `columns/bibsonomy.html` to load `bibsonomy_templatetags` and use the `link_to_reference_on` tag with modal functionality for reference linking.