### PR TITLE
fix(bibsonomy): use default str when incomplete

### DIFF
--- a/apis_ontology/templatetags/references.py
+++ b/apis_ontology/templatetags/references.py
@@ -1,3 +1,5 @@
+
+import logging
 from django import template
 from apis_bibsonomy.models import Reference
 import json
@@ -12,15 +14,37 @@ def get_references(content_type, object_id):
 
     for ref in refs_qs:
         # Assuming ref.bibtex is stored as JSON string
-        data = json.loads(ref.bibtex)
-        author = data["author"][0]
-        year = data["issued"]["date-parts"][0][0]
-        title = data["title"]
-        formatted_refs.append(
-            f"{author['family']}, {author['given']} ({year}). {title}"
-        )
+        try:
+            data = json.loads(ref.bibtex)
+            parts = []
+            author = data.get("author", [{}])
+            if author and isinstance(author, list) and author[0]:
+                a = author[0]
+                name = []
+                if 'family' in a:
+                    name.append(a['family'])
+                if 'given' in a:
+                    name.append(a['given'])
+                if name:
+                    parts.append(", ".join(name))
+            year = None
+            issued = data.get("issued", {})
+            if isinstance(issued, dict):
+                date_parts = issued.get("date-parts", [])
+                if date_parts and isinstance(date_parts, list) and date_parts[0]:
+                    year = date_parts[0][0] if len(date_parts[0]) > 0 else None
+            if year:
+                parts.append(f"({year})")
+            title = data.get("title")
+            if title:
+                parts.append(title)
+            if parts:
+                formatted_refs.append(". ".join(parts))
+            else:
+                logging.warning(f"Could not construct custom reference for Reference id={ref.id}, using default string.")
+                formatted_refs.append(str(ref))
+        except (json.JSONDecodeError, IndexError, AttributeError, TypeError) as e:
+            logging.warning(f"Error parsing Reference id={ref.id}: {e}. Using default string representation.")
+            formatted_refs.append(str(ref))
 
     return formatted_refs
-
-
-# ref['author'][0]['family']}, {ref['author'][0]['given']} ({ref['issued']['date-parts'][0][0]}).


### PR DESCRIPTION
This pull request improves the robustness and error handling of the `get_references` function in `apis_ontology/templatetags/references.py`, making reference formatting more resilient to malformed or incomplete data.

Error handling and logging:

* Added a `try/except` block to gracefully handle JSON parsing and data extraction errors, logging warnings and falling back to the default string representation when necessary.
* Imported the `logging` module to support warning messages for problematic references.

Reference formatting improvements:

* Updated the reference formatting logic to use safer dictionary access (`get`) and to check for missing fields, preventing crashes when data is incomplete or missing.