### PR TITLE
fix: handle None in location for monuments

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -1,3 +1,5 @@
+import logging
+
 from apis_core.apis_entities.abc import (
     E21_Person,
     E53_Place,
@@ -13,6 +15,9 @@ from django_interval.fields import FuzzyDateParserField
 from .date_utils import nomansland_dateparser
 from auditlog.registry import auditlog
 from django.utils.functional import cached_property
+
+
+logger = logging.getLogger(__name__)
 
 
 class IADateMixin(models.Model):
@@ -147,8 +152,11 @@ class Monument(IABaseModel, PreservationStateMixin):
         )
 
     def __str__(self):
-        if self.location.exists():
+        try:
             return f"{self.name} ({self.location.first()})"
+        except Exception as e:
+            logger.warning(f"Error in Monument __str__: {e}")
+
         return self.name
 
 


### PR DESCRIPTION
This pull request introduces improved error handling and logging to the `Monument` model's string representation in `apis_ontology/models.py`. The main change is the addition of a try-except block to gracefully handle potential errors when accessing related location data, along with logging for easier debugging.

**Error handling and logging improvements:**

* Added import and initialization of the `logging` module, and defined a `logger` for the module. [[1]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R1-R2) [[2]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R20-R22)
* Updated the `__str__` method of the `Monument` model to wrap the location access in a try-except block, logging a warning if an error occurs, instead of raising an exception.