### PR TITLE
feat(templates): always open URLs in a new window

### DIFF
--- a/apis_ontology/templates/generic/partials/default_model_field_value.html
+++ b/apis_ontology/templates/generic/partials/default_model_field_value.html
@@ -1,1 +1,3 @@
-{% if value %}{% autoescape off %}{{ value|urlize|linebreaksbr }}{% endautoescape %}{% endif %}
+{% load custom_filters %}
+
+{% if value %}{% autoescape off %}{{ value|urlize_newtab|linebreaksbr }}{% endautoescape %}{% endif %}

--- a/apis_ontology/templatetags/custom_filters.py
+++ b/apis_ontology/templatetags/custom_filters.py
@@ -1,0 +1,13 @@
+# templatetags/custom_filters.py
+from django import template
+from django.template.defaultfilters import urlize
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.filter
+def urlize_newtab(value):
+    result = urlize(value)
+    result = result.replace("<a ", '<a target="_blank" rel="noopener noreferrer" ')
+    return mark_safe(result)


### PR DESCRIPTION
closes #88

This pull request updates how URLs are rendered in template fields to improve user experience and security by ensuring links open in new tabs. The main changes introduce a custom Django template filter and update the template to use it.

**Template rendering improvements:**

* Added a new custom template filter `urlize_newtab` in `custom_filters.py` that modifies all auto-linked URLs to open in a new browser tab and adds `rel="noopener noreferrer"` for security.
* Updated `default_model_field_value.html` to use the new `urlize_newtab` filter instead of the default `urlize`, ensuring all rendered links open in a new tab.