### PR TITLE
fix: actions column

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -11,7 +11,7 @@ class IABaseModelTable(GenericTable):
             "id",
             "noduplicate",
         )
-        sequence = ("...", "view", "edit", "delete")
+        sequence = ("...", "actions")
 
 
 class PersonTable(IABaseModelTable):


### PR DESCRIPTION
This pull request makes a small update to the `Meta` class for a table definition in `apis_ontology/tables.py`. The change simplifies the `sequence` attribute by replacing the individual action names with a single `"actions"` entry.