### PR TITLE
fix(entities):preserve html formatting in text fields

### DIFF
--- a/apis_ontology/templatetags/custom_filters.py
+++ b/apis_ontology/templatetags/custom_filters.py
@@ -2,12 +2,38 @@
 from django import template
 from django.template.defaultfilters import urlize
 from django.utils.safestring import mark_safe
+from html.parser import HTMLParser
 
 register = template.Library()
 
+class URLizingParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.result = []
+        self.in_tag = False
+
+    def handle_starttag(self, tag, attrs):
+        self.result.append(self.get_starttag_text())
+        self.in_tag = True
+
+    def handle_endtag(self, tag):
+        self.result.append(f'</{tag}>')
+        self.in_tag = False
+
+    def handle_data(self, data):
+        if not self.in_tag:
+            # Urlize only the data (text content)
+            self.result.append(urlize(data))
+        else:
+            self.result.append(data)
 
 @register.filter
 def urlize_newtab(value):
-    result = urlize(value)
-    result = result.replace("<a ", '<a target="_blank" rel="noopener noreferrer" ')
+    if not value:
+        return value
+    parser = URLizingParser()
+    parser.feed(str(value))
+    result = ''.join(parser.result)
+    # Now modify links to open in new tab
+    result = result.replace('<a ', '<a target="_blank" rel="noopener noreferrer" ')
     return mark_safe(result)


### PR DESCRIPTION
This pull request refactors the `urlize_newtab` template filter to more safely and accurately convert URLs in text to clickable links that open in a new tab. The main improvement is the introduction of a custom HTML parser to ensure only plain text (not HTML tags) is processed, preventing accidental modification of existing HTML.

Enhancements to URL handling and HTML safety:

* Added a `URLizingParser` class using `HTMLParser` to selectively apply `urlize` only to text nodes, avoiding interference with existing HTML tags.
* Updated the `urlize_newtab` filter to use the new parser, ensuring that only plain text is converted to links and that all generated links open in a new tab with proper security attributes.