### PR TITLE
fix: autoescape details table to allow formatting from field values

### DIFF
--- a/apis_ontology/templates/apis_ontology/partials/iabasemodel_card_table.html
+++ b/apis_ontology/templates/apis_ontology/partials/iabasemodel_card_table.html
@@ -1,5 +1,6 @@
 {% load generic %}
 {% load references %}
+{% autoescape off %}
 {% block details %}
 <table class="table table-hover">
     {% modeldict object as d %}
@@ -9,6 +10,7 @@
     {% endfor %}
 </table>
 {% endblock details %}
+{% endautoescape %}
 {% block references %}
 {% with refs=object.content_type.id|get_references:object.pk %}
     {% if refs %}


### PR DESCRIPTION
This pull request updates the `iabasemodel_card_table.html` template to modify how HTML escaping is handled. The main change is the addition of Django's `{% autoescape off %}` and `{% endautoescape %}` tags around the table rendering block, which disables automatic HTML escaping for the content inside.

Template rendering changes:

* Wrapped the details table rendering block in `{% autoescape off %}` and `{% endautoescape %}` to disable automatic HTML escaping for the table content. [[1]](diffhunk://#diff-56c59681dbc641144a0692b1b7941a74bd9e2af1e31d491339c6f9df5a9c7f0cR3) [[2]](diffhunk://#diff-56c59681dbc641144a0692b1b7941a74bd9e2af1e31d491339c6f9df5a9c7f0cR13)