### PR TITLE
fix(tables): put kunya before ism

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -38,8 +38,8 @@ class InscriptionPersonRelationsTable(IABaseModelRelationsTable):
     def render_full_name(self, record):
         parts = [
             getattr(record, "person_title", None),
-            getattr(record, "ism", None),
             getattr(record, "kunya", None),
+            getattr(record, "ism", None),
             getattr(record, "nasab", None),
             getattr(record, "nisba", None),
             getattr(record, "relation_to_caliph", None),


### PR DESCRIPTION
This pull request makes a minor adjustment to the ordering of fields when rendering a person's full name in the `render_full_name` method. The `ism` field is now rendered after `kunya` instead of before it.

- Changed the order of fields in the `render_full_name` method in `apis_ontology/tables.py` so that `ism` appears after `kunya`. fixes #125