### PR TITLE
Collections filter

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -8,9 +8,11 @@ from apis_core.apis_entities.abc import (
     SimpleLabelModel,
 )
 from apis_core.apis_entities.models import AbstractEntity
+from apis_core.collections.models import SkosCollectionContentObject
 from apis_core.generic.abc import GenericModel
 from apis_core.history.models import VersionMixin
 from apis_core.relations.models import Relation
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django_interval.fields import FuzzyDateParserField
 
@@ -722,7 +724,7 @@ class MonumentConnectedToMonument(IARelationMixin):
 
 class GraphSearchSnapshot(models.Model):
     DEFAULT_KEY = "global"
-    CACHE_KEY = "graph_nodes_links_snapshot"
+    CACHE_KEY = "graph_nodes_links_snapshot_v2"
 
     key = models.CharField(max_length=64, unique=True, default=DEFAULT_KEY)
     nodes = models.JSONField(default=list, blank=True)
@@ -780,16 +782,47 @@ class GraphSearchSnapshot(models.Model):
 
             return label, reverse_label
 
-        def add_nodes(qs, group):
+        def get_collections_by_object_id(model, object_ids):
+            if not object_ids:
+                return {}
+
+            content_type = ContentType.objects.get_for_model(model)
+            collection_map = {}
+            collection_links = (
+                SkosCollectionContentObject.objects.filter(
+                    content_type=content_type,
+                    object_id__in=object_ids,
+                )
+                .select_related("collection")
+                .iterator(chunk_size=5000)
+            )
+            for link in collection_links:
+                collection_map.setdefault(link.object_id, []).append(
+                    {
+                        "id": link.collection_id,
+                        "label": str(link.collection),
+                    }
+                )
+            return collection_map
+
+        def add_nodes(qs, group, collection_map):
             for obj in qs:
-                nodes.append({"id": obj.id, "label": str(obj), "group": group})
+                node = {"id": obj.id, "label": str(obj), "group": group}
+                collections = collection_map.get(obj.id, [])
+                if collections:
+                    node["collection_ids"] = [collection["id"] for collection in collections]
+                    node["collections"] = collections
+                nodes.append(node)
 
         seen_models = set()
         for model in iter_iabase_models(IABaseModel):
             if model in seen_models:
                 continue
             seen_models.add(model)
-            add_nodes(model.objects.only("id"), model._meta.model_name)
+            queryset = model.objects.only("id")
+            object_ids = list(queryset.values_list("id", flat=True))
+            collection_map = get_collections_by_object_id(model, object_ids)
+            add_nodes(queryset, model._meta.model_name, collection_map)
 
         node_ids = {n["id"] for n in nodes}
         links = []

--- a/apis_ontology/templates/django_cosmograph/cosmograph.html
+++ b/apis_ontology/templates/django_cosmograph/cosmograph.html
@@ -14,6 +14,14 @@
                 aria-label="Filter graph"
             >
         </div>
+        <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+            <select name="collection" class="form-select form-select-sm" aria-label="Filter by collection">
+                <option value="">All collections</option>
+                {% for collection in graph_collection_choices %}
+                <option value="{{ collection.id }}" {% if collection.id in graph_selected_collection_ids %}selected{% endif %}>{{ collection.label }}</option>
+                {% endfor %}
+            </select>
+        </div>
         <div class="col-auto">
             <button type="submit" class="btn btn-primary btn-sm">Filter</button>
         </div>

--- a/apis_ontology/views.py
+++ b/apis_ontology/views.py
@@ -4,6 +4,8 @@ from django.core.cache import cache
 import json
 import math
 import logging
+from django_cosmograph.utils import assign_node_sizes
+
 logger = logging.getLogger(__name__)
 
 class GraphView(CosmographView):
@@ -102,24 +104,6 @@ class GraphView(CosmographView):
         }
         return [node for node in nodes if node.get("id") in linked_node_ids], links
 
-    def _assign_linkless_fallback_positions(self, nodes, links):
-        linked_node_ids = {
-            endpoint
-            for link in links
-            for endpoint in (link.get("source"), link.get("target"))
-            if endpoint is not None
-        }
-        linkless_nodes = [n for n in nodes if n.get("id") not in linked_node_ids]
-        if linkless_nodes:
-            radius = max(20.0, len(linkless_nodes) * 3.0)
-            for index, node in enumerate(linkless_nodes):
-                if "x" in node and "y" in node:
-                    continue
-                angle = (2.0 * math.pi * index) / len(linkless_nodes)
-                node["x"] = round(radius * math.cos(angle), 3)
-                node["y"] = round(radius * math.sin(angle), 3)
-        return nodes
-
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         snapshot_nodes, _ = self._get_snapshot_nodes_links()
@@ -187,11 +171,6 @@ class GraphView(CosmographView):
             if node.get("id") in visible_node_ids and node not in filtered_nodes:
                 filtered_nodes.append(node)
 
-        # Cosmograph can fail to place linkless nodes in a visible region.
-        filtered_nodes = self._assign_linkless_fallback_positions(
-            filtered_nodes, filtered_links
-        )
-
         return filtered_nodes, filtered_links
 
     def get_nodes_links(self):
@@ -200,11 +179,11 @@ class GraphView(CosmographView):
 
         nodes, links = self._apply_collection_filter(nodes, links)
         nodes, links = self._filter_nodes_links(nodes, links)
-        nodes = self._assign_linkless_fallback_positions(nodes, links)
         nodes = self._serialize_nodes_for_cosmograph(nodes)
         logger.debug(
             f"After filtering, graph has {len(nodes)} nodes and {len(links or [])} links"
         )
+        
         nodes, links = self._apply_unconnected_visibility(nodes, links)
         self._graph_has_links = bool(links)
         if not links and nodes:

--- a/apis_ontology/views.py
+++ b/apis_ontology/views.py
@@ -9,12 +9,89 @@ logger = logging.getLogger(__name__)
 class GraphView(CosmographView):
     # TODO: How do I restrict the view based on user permissions
 
+    def _get_selected_collection_ids(self):
+        values = []
+        for value in self.request.GET.getlist("collection"):
+            if not value:
+                continue
+            values.extend(part.strip() for part in value.split(","))
+
+        selected_ids = set()
+        for value in values:
+            if value.isdigit():
+                selected_ids.add(int(value))
+        return selected_ids
+
+    def _apply_collection_filter(self, nodes, links):
+        selected_collection_ids = self._get_selected_collection_ids()
+        if not selected_collection_ids:
+            return nodes, links
+
+        filtered_nodes = [
+            node
+            for node in nodes
+            if selected_collection_ids.intersection(node.get("collection_ids", []))
+        ]
+        filtered_node_ids = {node.get("id") for node in filtered_nodes}
+
+        filtered_links = [
+            link
+            for link in links
+            if link.get("source") in filtered_node_ids
+            and link.get("target") in filtered_node_ids
+        ]
+
+        return filtered_nodes, filtered_links
+
+    def _collection_choices(self, nodes):
+        choices = {}
+        for node in nodes:
+            for collection in node.get("collections", []):
+                collection_id = collection.get("id")
+                if collection_id is None:
+                    continue
+                choices[collection_id] = collection.get("label", str(collection_id))
+
+        return [
+            {"id": collection_id, "label": label}
+            for collection_id, label in sorted(
+                choices.items(), key=lambda item: item[1].lower()
+            )
+        ]
+
+    def _serialize_nodes_for_cosmograph(self, nodes):
+        serialized_nodes = []
+        for node in nodes:
+            clean_node = dict(node)
+            clean_node.pop("collection_ids", None)
+            clean_node.pop("collections", None)
+            serialized_nodes.append(clean_node)
+        return serialized_nodes
+
+    def _get_snapshot_nodes_links(self):
+        cache_key = GraphSearchSnapshot.CACHE_KEY
+        cached_data = cache.get(cache_key)
+        if cached_data:
+            return json.loads(cached_data)
+
+        snapshot = GraphSearchSnapshot.objects.filter(
+            key=GraphSearchSnapshot.DEFAULT_KEY
+        ).first()
+        if snapshot is None:
+            logger.debug("Graph snapshot missing - rebuilding from source models")
+            snapshot = GraphSearchSnapshot.rebuild()
+
+        nodes = snapshot.nodes
+        links = snapshot.links
+        cache.set(cache_key, json.dumps((nodes, links)), 86400)
+        return nodes, links
+
     def _show_unconnected_nodes(self):
         value = self.request.GET.get("show_unconnected", "1").strip().lower()
         return value not in {"0", "false", "no", "off"}
 
     def _apply_unconnected_visibility(self, nodes, links):
-        if self._show_unconnected_nodes():
+        if not links or self._show_unconnected_nodes():
             return nodes, links
 
         linked_node_ids = {
@@ -25,11 +102,37 @@ class GraphView(CosmographView):
         }
         return [node for node in nodes if node.get("id") in linked_node_ids], links
 
+    def _assign_linkless_fallback_positions(self, nodes, links):
+        linked_node_ids = {
+            endpoint
+            for link in links
+            for endpoint in (link.get("source"), link.get("target"))
+            if endpoint is not None
+        }
+        linkless_nodes = [n for n in nodes if n.get("id") not in linked_node_ids]
+        if linkless_nodes:
+            radius = max(20.0, len(linkless_nodes) * 3.0)
+            for index, node in enumerate(linkless_nodes):
+                if "x" in node and "y" in node:
+                    continue
+                angle = (2.0 * math.pi * index) / len(linkless_nodes)
+                node["x"] = round(radius * math.cos(angle), 3)
+                node["y"] = round(radius * math.sin(angle), 3)
+        return nodes
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        snapshot_nodes, _ = self._get_snapshot_nodes_links()
         context["graph_query"] = self.request.GET.get("q", "").strip()
         context["graph_show_unconnected"] = self._show_unconnected_nodes()
+        context["graph_collection_choices"] = self._collection_choices(snapshot_nodes)
+        context["graph_selected_collection_ids"] = self._get_selected_collection_ids()
         return context
+
+    def get_params(self, *args, **kwargs):
+        params = super().get_params(*args, **kwargs)
+        params["renderLinks"] = getattr(self, "_graph_has_links", True)
+        return params
 
     def _filter_nodes_links(self, nodes, links):
         query = self.request.GET.get("q", "").strip().lower()
@@ -85,53 +188,34 @@ class GraphView(CosmographView):
                 filtered_nodes.append(node)
 
         # Cosmograph can fail to place linkless nodes in a visible region.
-        # Give them deterministic coordinates on a small circle as a fallback.
-        linked_node_ids = {
-            endpoint
-            for link in filtered_links
-            for endpoint in (link.get("source"), link.get("target"))
-            if endpoint is not None
-        }
-        linkless_nodes = [n for n in filtered_nodes if n.get("id") not in linked_node_ids]
-        if linkless_nodes:
-            radius = max(20.0, len(linkless_nodes) * 3.0)
-            for index, node in enumerate(linkless_nodes):
-                if "x" in node and "y" in node:
-                    continue
-                angle = (2.0 * math.pi * index) / len(linkless_nodes)
-                node["x"] = round(radius * math.cos(angle), 3)
-                node["y"] = round(radius * math.sin(angle), 3)
+        filtered_nodes = self._assign_linkless_fallback_positions(
+            filtered_nodes, filtered_links
+        )
 
         return filtered_nodes, filtered_links
 
     def get_nodes_links(self):
-        cache_key = GraphSearchSnapshot.CACHE_KEY
-        cached_data = cache.get(cache_key)
-        if cached_data:
-            nodes, links = json.loads(cached_data)
-            nodes, links = self._filter_nodes_links(nodes, links)
-            nodes, links = self._apply_unconnected_visibility(nodes, links)
-            logger.debug(
-                f"Loaded graph from cache with {len(nodes)} nodes and {len(links)} links"
-            )
-            return nodes, links
-
-        snapshot = GraphSearchSnapshot.objects.filter(
-            key=GraphSearchSnapshot.DEFAULT_KEY
-        ).first()
-        if snapshot is None:
-            logger.debug("Graph snapshot missing - rebuilding from source models")
-            snapshot = GraphSearchSnapshot.rebuild()
-
-        nodes = snapshot.nodes
-        links = snapshot.links
-
+        nodes, links = self._get_snapshot_nodes_links()
         logger.debug(f"Generated graph with {len(nodes)} nodes and {len(links)} links")
-        # Cache nodes and links as a JSON string for 24 hours
-        cache.set(cache_key, json.dumps((nodes, links)), 86400)
 
+        nodes, links = self._apply_collection_filter(nodes, links)
         nodes, links = self._filter_nodes_links(nodes, links)
+        nodes = self._assign_linkless_fallback_positions(nodes, links)
+        nodes = self._serialize_nodes_for_cosmograph(nodes)
         logger.debug(
-            f"After filtering, graph has {len(nodes)} nodes and {len(links)} links"
+            f"After filtering, graph has {len(nodes)} nodes and {len(links or [])} links"
         )
-        return self._apply_unconnected_visibility(nodes, links)
+        nodes, links = self._apply_unconnected_visibility(nodes, links)
+        self._graph_has_links = bool(links)
+        if not links and nodes:
+            node_id = nodes[0]["id"]
+            links = [
+                {
+                    "source": node_id,
+                    "target": node_id,
+                    "label": "",
+                    "reverse_label": "",
+                    "group": "__collection_placeholder__",
+                }
+            ]
+        return nodes, links


### PR DESCRIPTION
This pull request adds support for filtering graph nodes by collection in the ontology graph view. It introduces backend logic to annotate nodes with their collection memberships, provides a UI filter for collections, and ensures the filtering is applied efficiently to both nodes and links. Additionally, it refactors the caching and retrieval of graph data for better maintainability.

**Collection Filtering and Annotation:**

- Nodes are now annotated with their associated collections and collection IDs during graph snapshot generation, using the new `get_collections_by_object_id` helper and updated `add_nodes` logic in `apis_ontology/models.py`.
- The graph view (`GraphView` in `apis_ontology/views.py`) adds methods to extract selected collection IDs from the request, filter nodes and links by these collections, and provide collection choices to the template. [[1]](diffhunk://#diff-6288409a4037e048fa138cacd118a2f0ac6c526f0f549209c0c1b106c4d1f5b4R7-R96) [[2]](diffhunk://#diff-6288409a4037e048fa138cacd118a2f0ac6c526f0f549209c0c1b106c4d1f5b4R109-R120)

**User Interface Enhancements:**

- The graph filter UI (`cosmograph.html`) now includes a dropdown to filter by collection, populated dynamically from the available collections in the current graph snapshot.

**Caching and Data Retrieval Refactor:**

- The cache key for the graph snapshot is versioned to avoid conflicts with previous formats, and the logic for retrieving and caching the snapshot is consolidated into a single helper method. [[1]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L725-R727) [[2]](diffhunk://#diff-6288409a4037e048fa138cacd118a2f0ac6c526f0f549209c0c1b106c4d1f5b4R7-R96) [[3]](diffhunk://#diff-6288409a4037e048fa138cacd118a2f0ac6c526f0f549209c0c1b106c4d1f5b4L87-R200)

**Graph Rendering Robustness:**

- Ensures that when all links are filtered out but nodes remain, a placeholder self-link is added to prevent rendering issues in the graph visualization.

**Context Data and Serialization:**

- The context for the template now includes the available collection choices and the currently selected collections, and nodes are serialized to remove collection metadata before being sent to the frontend. [[1]](diffhunk://#diff-6288409a4037e048fa138cacd118a2f0ac6c526f0f549209c0c1b106c4d1f5b4R109-R120) [[2]](diffhunk://#diff-6288409a4037e048fa138cacd118a2f0ac6c526f0f549209c0c1b106c4d1f5b4R7-R96)