### PR TITLE
feat(graph): remove unconnected nodes toggle

### DIFF
--- a/apis_ontology/templates/django_cosmograph/cosmograph.html
+++ b/apis_ontology/templates/django_cosmograph/cosmograph.html
@@ -3,7 +3,6 @@
 {% block dc_content %}
 <div class="container-fluid py-2">
     <form method="get" class="row g-2 align-items-center justify-content-center mb-2">
-        <input type="hidden" name="show_unconnected" value="{{ graph_show_unconnected|yesno:'1,0' }}">
         <div class="col-12 col-sm-10 col-md-8 col-lg-6">
             <input
                 type="search"
@@ -25,16 +24,9 @@
         <div class="col-auto">
             <button type="submit" class="btn btn-primary btn-sm">Filter</button>
         </div>
-        <div class="col-auto">
-            {% if graph_show_unconnected %}
-            <button type="submit" name="show_unconnected" value="0" class="btn btn-outline-dark btn-sm">Hide Unconnected</button>
-            {% else %}
-            <button type="submit" name="show_unconnected" value="1" class="btn btn-outline-dark btn-sm">Show Unconnected</button>
-            {% endif %}
-        </div>
         {% if graph_query %}
         <div class="col-auto">
-            <a href="?show_unconnected={{ graph_show_unconnected|yesno:'1,0' }}" class="btn btn-outline-secondary btn-sm">Clear</a>
+            <a href="" class="btn btn-outline-secondary btn-sm">Clear</a>
         </div>
         {% endif %}
     </form>

--- a/apis_ontology/views.py
+++ b/apis_ontology/views.py
@@ -88,27 +88,10 @@ class GraphView(CosmographView):
         cache.set(cache_key, json.dumps((nodes, links)), 86400)
         return nodes, links
 
-    def _show_unconnected_nodes(self):
-        value = self.request.GET.get("show_unconnected", "1").strip().lower()
-        return value not in {"0", "false", "no", "off"}
-
-    def _apply_unconnected_visibility(self, nodes, links):
-        if not links or self._show_unconnected_nodes():
-            return nodes, links
-
-        linked_node_ids = {
-            endpoint
-            for link in links
-            for endpoint in (link.get("source"), link.get("target"))
-            if endpoint is not None
-        }
-        return [node for node in nodes if node.get("id") in linked_node_ids], links
-
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         snapshot_nodes, _ = self._get_snapshot_nodes_links()
         context["graph_query"] = self.request.GET.get("q", "").strip()
-        context["graph_show_unconnected"] = self._show_unconnected_nodes()
         context["graph_collection_choices"] = self._collection_choices(snapshot_nodes)
         context["graph_selected_collection_ids"] = self._get_selected_collection_ids()
         return context
@@ -184,7 +167,6 @@ class GraphView(CosmographView):
             f"After filtering, graph has {len(nodes)} nodes and {len(links or [])} links"
         )
         
-        nodes, links = self._apply_unconnected_visibility(nodes, links)
         self._graph_has_links = bool(links)
         if not links and nodes:
             node_id = nodes[0]["id"]


### PR DESCRIPTION
This pull request removes the "Show Unconnected" / "Hide Unconnected" toggle feature from the Cosmograph graph filter interface and its associated backend logic. The interface is simplified so that all nodes are always shown, regardless of whether they are connected by links.

Interface simplification:

* Removed the "Show Unconnected" / "Hide Unconnected" toggle buttons and the hidden input for `show_unconnected` from the `cosmograph.html` template, streamlining the filter form. [[1]](diffhunk://#diff-892af536ebaa85f6bb7220e244fd703099c715776ac0abf9e54f46ae25a31822L6) [[2]](diffhunk://#diff-892af536ebaa85f6bb7220e244fd703099c715776ac0abf9e54f46ae25a31822L28-R29)
* Updated the "Clear" button in the filter form to reset all filters by linking to the base URL, rather than preserving the `show_unconnected` state.

Backend cleanup:

* Removed the `_show_unconnected_nodes` and `_apply_unconnected_visibility` methods from `apis_ontology/views.py`, as well as all logic referencing `show_unconnected` in context data and node/link filtering, ensuring all nodes are always included in the graph. [[1]](diffhunk://#diff-6288409a4037e048fa138cacd118a2f0ac6c526f0f549209c0c1b106c4d1f5b4L91-L111) [[2]](diffhunk://#diff-6288409a4037e048fa138cacd118a2f0ac6c526f0f549209c0c1b106c4d1f5b4L187)